### PR TITLE
verify: return statement bits

### DIFF
--- a/src/pypi_attestation_models/_impl.py
+++ b/src/pypi_attestation_models/_impl.py
@@ -107,8 +107,12 @@ class Attestation(BaseModel):
 
         return sigstore_to_pypi(bundle)
 
-    def verify(self, verifier: Verifier, policy: VerificationPolicy, dist: Path) -> None:
+    def verify(
+        self, verifier: Verifier, policy: VerificationPolicy, dist: Path
+    ) -> tuple[str, dict[str, Any] | None]:
         """Verify against an existing Python artifact.
+
+        Returns a tuple of the in-toto predicate type and optional deserialized JSON predicate.
 
         On failure, raises an appropriate subclass of `AttestationError`.
         """
@@ -153,6 +157,8 @@ class Attestation(BaseModel):
         digest = subject.digest.root.get("sha256")
         if digest is None or digest != expected_digest:
             raise VerificationError("subject does not match distribution digest")
+
+        return statement.predicate_type, statement.predicate
 
 
 class Envelope(BaseModel):

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -61,7 +61,9 @@ class TestAttestation:
         bundle = Bundle.from_json(gh_signed_bundle_path.read_bytes())
         attestation = impl.sigstore_to_pypi(bundle)
 
-        attestation.verify(verifier, pol, gh_signed_artifact_path)
+        predicate_type, predicate = attestation.verify(verifier, pol, gh_signed_artifact_path)
+        assert predicate_type == "https://docs.pypi.org/attestations/publish/v1"
+        assert predicate == {}
 
     def test_verify(self) -> None:
         verifier = Verifier.staging()
@@ -71,7 +73,10 @@ class TestAttestation:
         )
 
         attestation = impl.Attestation.model_validate_json(attestation_path.read_text())
-        attestation.verify(verifier, pol, artifact_path)
+        predicate_type, predicate = attestation.verify(verifier, pol, artifact_path)
+
+        assert predicate_type == "https://docs.pypi.org/attestations/publish/v1"
+        assert predicate is None
 
         # convert the attestation to a bundle and verify it that way too
         bundle = impl.pypi_to_sigstore(attestation)


### PR DESCRIPTION
This tweaks the `verify` API to return the in-toto predicate type and payload, which might be `None` if no payload is explicitly encoded. 

Also updates the tests to assert those return values.