### PR TITLE
Rename to pypi-attestations

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Renamed project to pypi-attestations
+2fefc5a178844cff0c0b4e192ca055e4816ca90d

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-PY_IMPORT = pypi_attestation_models
+PY_IMPORT = pypi_attestations
 
 ALL_PY_SRCS := $(shell find src -name '*.py') \
 	$(shell find test -name '*.py')

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ python -m pip install pypi-attestation-models
 ## Usage as a command line tool
 
 ````bash
-python -m pypi_attestation_models --help
-usage: pypi-attestation-models [-h] [-v] [-V] COMMAND ...
+python -m pypi_attestations --help
+usage: pypi-attestation [-h] [-v] [-V] COMMAND ...
 
 Sign, inspect or verify PEP 740 attestations
 
@@ -30,7 +30,7 @@ positional arguments:
 
 options:
   -h, --help     show this help message and exit
-  -v, --verbose  run with additional debug logging; supply multiple times to 
+  -v, --verbose  run with additional debug logging; supply multiple times to
                  increase verbosity (default: 0)
   -V, --version  show program's version number and exit
 ````
@@ -40,29 +40,29 @@ options:
 ```bash
 # Generate a whl file
 make package
-python -m pypi_attestation_models sign dist/pypi_attestation_models-*.whl
+python -m pypi_attestations sign dist/pypi_attestations-*.whl
 ```
 
-_Note_: This will open a browser window to authenticate with the Sigstore 
+_Note_: This will open a browser window to authenticate with the Sigstore
 OAuth flow.
 
 ### Inspecting a PEP 740 Attestation
 
 ```bash
-python -m pypi_attestation_models inspect dist/pypi_attestation_models-*.whl.publish.attestation
+python -m pypi_attestations inspect dist/pypi_attestations-*.whl.publish.attestation
 ```
-_Warning_: Inspecting does not mean verifying. It only prints the structure of 
+_Warning_: Inspecting does not mean verifying. It only prints the structure of
 the attestation.
 
 ### Verifying a PEP 740 Attestation
 
 ```bash
-python -m pypi_attestation_models verify --staging \
+python -m pypi_attestations verify --staging \
   --identity william@yossarian.net \
   test/assets/rfc8785-0.1.2-py3-none-any.whl
 ```
-The attestation present in the test has been generated using the staging 
-environment of Sigstore and signed by William. 
+The attestation present in the test has been generated using the staging
+environment of Sigstore and signed by William.
 
 ## Usage as a library
 
@@ -76,7 +76,7 @@ Use these APIs to create a PEP 740-compliant `Attestation` object by signing a P
 ```python
 from pathlib import Path
 
-from pypi_attestation_models import Attestation
+from pypi_attestations import Attestation
 from sigstore.oidc import Issuer
 from sigstore.sign import SigningContext
 from sigstore.verify import Verifier, policy
@@ -106,7 +106,7 @@ by signing a distribution file.
 
 ```python
 from pathlib import Path
-from pypi_attestation_models import Attestation
+from pypi_attestations import Attestation
 from sigstore.models import Bundle
 
 # Sigstore Bundle -> PEP 740 Attestation object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=3.5,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "pypi-attestation-models"
+name = "pypi-attestations"
 dynamic = ["version"]
 description = "A library to convert between Sigstore Bundles and PEP-740 Attestation objects"
 readme = "README.md"
@@ -35,28 +35,28 @@ lint = [
     "types-toml",
     "interrogate",
 ]
-dev = ["pypi-attestation-models[doc,test,lint]", "twine", "wheel", "build"]
+dev = ["pypi-attestations[doc,test,lint]", "twine", "wheel", "build"]
 
 
 [project.urls]
-Homepage = "https://pypi.org/project/pypi-attestation-models"
-Documentation = "https://trailofbits.github.io/pypi-attestation-models/"
-Issues = "https://github.com/trailofbits/pypi-attestation-models/issues"
-Source = "https://github.com/trailofbits/pypi-attestation-models"
+Homepage = "https://pypi.org/project/pypi-attestations"
+Documentation = "https://trailofbits.github.io/pypi-attestations/"
+Issues = "https://github.com/trailofbits/pypi-attestations/issues"
+Source = "https://github.com/trailofbits/pypi-attestations"
 
 [tool.flit.module]
-name = "pypi_attestation_models"
+name = "pypi_attestations"
 
 [tool.coverage.run]
 # don't attempt code coverage for the CLI entrypoints
 omit = [
-    "src/pypi_attestation_models/_cli.py",
-    "src/pypi_attestation_models/__main__.py"
+    "src/pypi_attestations/_cli.py",
+    "src/pypi_attestations/__main__.py"
 ]
 
 [tool.mypy]
 mypy_path = "src"
-packages = "pypi_attestation_models"
+packages = "pypi_attestations"
 allow_redefinition = true
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -99,8 +99,8 @@ ignore = ["ANN101", "ANN102", "D203", "D213", "COM812", "ISC001"]
 exclude = [
     "env",
     "test",
-    "src/pypi_attestation_models/_cli.py",
-    "src/pypi_attestation_models/__main__.py"
+    "src/pypi_attestations/_cli.py",
+    "src/pypi_attestations/__main__.py"
 ]
 ignore-semiprivate = true
 fail-under = 100

--- a/src/pypi_attestation_models/__main__.py
+++ b/src/pypi_attestation_models/__main__.py
@@ -1,6 +1,0 @@
-"""The pypi-attestation-models entrypoint."""
-
-if __name__ == "__main__":
-    from pypi_attestation_models._cli import main
-
-    main()

--- a/src/pypi_attestations/__init__.py
+++ b/src/pypi_attestations/__init__.py
@@ -1,4 +1,4 @@
-"""The `pypi-attestation-models` APIs."""
+"""The `pypi-attestations` APIs."""
 
 __version__ = "0.0.5"
 

--- a/src/pypi_attestations/__main__.py
+++ b/src/pypi_attestations/__main__.py
@@ -1,0 +1,6 @@
+"""The pypi-attestations entrypoint."""
+
+if __name__ == "__main__":
+    from pypi_attestations._cli import main
+
+    main()

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -13,7 +13,7 @@ from sigstore.oidc import IdentityError, IdentityToken, Issuer
 from sigstore.sign import SigningContext
 from sigstore.verify import Verifier, policy
 
-from pypi_attestation_models import Attestation, AttestationError, VerificationError, __version__
+from pypi_attestations import Attestation, AttestationError, VerificationError, __version__
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -36,7 +36,7 @@ def _parser() -> argparse.ArgumentParser:
     )
 
     parser = argparse.ArgumentParser(
-        prog="pypi-attestation-models",
+        prog="pypi-attestations",
         description="Sign, inspect or verify PEP 740 attestations",
         parents=[parent_parser],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -46,7 +46,7 @@ def _parser() -> argparse.ArgumentParser:
         "-V",
         "--version",
         action="version",
-        version=f"pypi-attestation-models {__version__}",
+        version=f"pypi-attestations {__version__}",
     )
 
     subcommands = parser.add_subparsers(

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -36,7 +36,7 @@ def _parser() -> argparse.ArgumentParser:
     )
 
     parser = argparse.ArgumentParser(
-        prog="pypi-attestations",
+        prog="python -m pypi_attestations",
         description="Sign, inspect or verify PEP 740 attestations",
         parents=[parent_parser],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -1,4 +1,4 @@
-"""Internal implementation module for `pypi-attestation-models`.
+"""Internal implementation module for `pypi-attestations`.
 
 This module is NOT a public API, and is not considered stable.
 """

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,16 +8,16 @@ import sys
 import tempfile
 from pathlib import Path
 
-import pypi_attestation_models._cli
+import pypi_attestations._cli
 import pytest
 import sigstore.oidc
-from pypi_attestation_models._cli import (
+from pypi_attestations._cli import (
     _logger,
     _validate_files,
     get_identity_token,
     main,
 )
-from pypi_attestation_models._impl import Attestation
+from pypi_attestations._impl import Attestation
 from sigstore.oidc import IdentityError
 
 ONLINE_TESTS = "CI" in os.environ or "TEST_INTERACTIVE" in os.environ
@@ -41,7 +41,7 @@ def test_main_verbose_level(monkeypatch: pytest.MonkeyPatch) -> None:
     def default_sign(_: argparse.Namespace) -> None:
         return
 
-    monkeypatch.setattr(pypi_attestation_models._cli, "_sign", default_sign)
+    monkeypatch.setattr(pypi_attestations._cli, "_sign", default_sign)
 
     run_main_with_command(["sign", "-v", ""])
     assert _logger.level == logging.DEBUG

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 import pretend
-import pypi_attestation_models._impl as impl
+import pypi_attestations._impl as impl
 import pytest
 from sigstore.dsse import _DigestSet, _StatementBuilder, _Subject
 from sigstore.models import Bundle

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,9 +1,9 @@
 """Initial testing module."""
 
-import pypi_attestation_models
+import pypi_attestations
 
 
 def test_version() -> None:
-    version = getattr(pypi_attestation_models, "__version__", None)
+    version = getattr(pypi_attestations, "__version__", None)
     assert version is not None
     assert isinstance(version, str)


### PR DESCRIPTION
Fixes #6

TODO : 
- [ ] Change repo URL
- [ ] Rename artifacts in the assets ?
- [ ] Update trusted publisher on PyPI (@woodruffw will do this)